### PR TITLE
map function errors

### DIFF
--- a/lib/levenshtein.js
+++ b/lib/levenshtein.js
@@ -20,7 +20,7 @@
   function map( array, fn ) { var result
     result = Array( array.length )
     forEach( array, function ( val, i, array ) {
-      result.push( fn( val, i, array ) )
+      result[i] = fn( val, i, array )
     })
     return result
   }


### PR DESCRIPTION
`.push()` adds to the end of an array
if the array has been created via `new Array( length )` then results will be offset by that `length`
